### PR TITLE
Avoid non_fmt_panic warning on Rust 1.50.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ macro_rules! enable_sections {
 #[macro_export]
 macro_rules! section {
   ($name:expr) => {{
-    assert!($crate::is_running(), "\"section!(...)\" must be called from inside \"enable_sections! { ... }\"");
+    assert!($crate::is_running(), "{}", "\"section!(...)\" must be called from inside \"enable_sections! { ... }\"");
     $crate::enter_section($name, file!(), line!())
   }}
 }

--- a/tests/example.rs
+++ b/tests/example.rs
@@ -1,0 +1,40 @@
+#[macro_use]
+extern crate section_testing;
+
+enable_sections! {
+  #[test]
+  fn example_test() {
+    let mut v: Vec<i32> = vec![];
+
+    fn check_123(v: &mut Vec<i32>) {
+      assert_eq!(*v, vec![1, 2, 3]);
+
+      if section!("reverse") {
+        v.reverse();
+        assert_eq!(*v, vec![3, 2, 1]);
+      }
+
+      if section!("pop+remove+insert+push") {
+        let three = v.pop().unwrap();
+        let one = v.remove(0);
+        v.insert(0, three);
+        v.push(one);
+        assert_eq!(*v, vec![3, 2, 1]);
+      }
+    }
+
+    if section!("push") {
+      v.push(1);
+      v.push(2);
+      v.push(3);
+      check_123(&mut v);
+    }
+
+    if section!("insert") {
+      v.insert(0, 3);
+      v.insert(0, 1);
+      v.insert(1, 2);
+      check_123(&mut v);
+    }
+  }
+}


### PR DESCRIPTION
Hi! :wave: Rust 1.50.0 just came out, and this library now triggers a `non_fmt_panic` warning. I took it upon myself to fix it. I checked, and it still builds even with Rust 1.31.0.

(Looks like you haven't touched Rust in a few years, so if you don't have time for this, please consider passing the library on. [A project I'm maintaining](https://github.com/newsboat/newsboat) depends on section_testing, and I also help out maintaining [a few](https://github.com/Koka/gettext-rs) [other](https://github.com/Minoru/hakyll-convert) [projects](https://github.com/jaspervdj/hakyll), so this library should be safe with me :)